### PR TITLE
Post(記事)作成編集時に画像をプレビューで見れるようにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,5 +82,7 @@ USER 1000:1000
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
 # Start server via Thruster by default, this can be overwritten at runtime
-EXPOSE 80
-CMD ["./bin/thrust", "./bin/rails", "server"]
+# EXPOSE 80
+# CMD ["./bin/thrust", "./bin/rails", "server"]
+EXPOSE 3000
+CMD ["./bin/rails", "server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,5 +84,5 @@ ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 # Start server via Thruster by default, this can be overwritten at runtime
 # EXPOSE 80
 # CMD ["./bin/thrust", "./bin/rails", "server"]
-EXPOSE 3000
-CMD ["./bin/rails", "server"]
+EXPOSE 80
+CMD ["./bin/thrust", "./bin/rails", "server"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -37,8 +37,6 @@ RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs ya
 # vim : テキストエディタ
 RUN apt-get update -qq && apt-get install -y imagemagick libvips42
 # imagemagick libvips42 : ActiveStrageで画像のリサイズに必要
-RUN apt-get update -qq && apt-get install -y cron
-# 定時処理を行うwheneverを使うためのcronパッケージのインストールをする
 
 RUN mkdir /myapp
 # コンテナ内に/myappというディレクトリを作成するコマンド

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import PreviewController from "./preview_controller"
+application.register("preview", PreviewController)

--- a/app/javascript/controllers/preview_controller.js
+++ b/app/javascript/controllers/preview_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "preview", "existing"]
+
+  previewImage() {
+    const input = this.inputTarget
+    const preview = this.previewTarget
+    const existing = this.existingTarget
+    const files = input.files   
+    // HTMLの<input type="file">要素から選択されたファイルの配列を取得できる
+    // 直接ビューに<input type="file">はないが「form.file_field :avatar」がそれを生成するRailsのヘルパーメソッド
+
+    if (existing) {existing.style.display = 'none';}
+    // 編集時、既存の画像は初期表示。この処理で非表示にする。
+
+    if (files.length > 0) {
+      const reader = new FileReader()
+      // new FileReaderを使うために特別な準備は必要ない。FileReaderはブラウザが提供するAPIだから、JavaScriptを実行できる環境があればすぐに使える。
+      // FileReaderテーブルみたいなのは不必要
+  
+      reader.onload = (e) => {preview.innerHTML = `<img src="${e.target.result}">`;}
+      // onloadはFileReaderのプロパティの一つ。ファイルの読み込みが完了したときに呼ばれるイベントハンドラーを設定するためのもの。
+      // ファイルの読み込みが成功したときに、指定された関数（ここではアロー関数）が実行される
+      // 「(e) => { ... }」はアロー関数の定義。eはイベントオブジェクトで、読み込みが完了したファイルに関する情報を持っている。
+      // 「preview.innerHTML」ビューで設定された「data-preview-target="preview"」を対象に中身を新しいHTMLに置き換えている
+      // 「e.target.result」には、読み込んだファイルのデータが格納されていて、これをsrc属性に設定することで、画像がブラウザで表示されるようになる
+  
+      reader.readAsDataURL(files[0])
+      // readAsDataURLは、FileReaderオブジェクトのメソッドの一つ。指定されたファイルを読み込み内容をデータURL形式で取得するために使う
+      // ファイルの内容を非同期に読み込み、読み込みが完了するとonloadイベントが発火する
+    }
+  }
+}

--- a/app/javascript/controllers/preview_controller.js
+++ b/app/javascript/controllers/preview_controller.js
@@ -19,7 +19,7 @@ export default class extends Controller {
       // new FileReaderを使うために特別な準備は必要ない。FileReaderはブラウザが提供するAPIだから、JavaScriptを実行できる環境があればすぐに使える。
       // FileReaderテーブルみたいなのは不必要
   
-      reader.onload = (e) => {preview.innerHTML = `<img src="${e.target.result}">`;}
+      reader.onload = (e) => {preview.innerHTML = `<img src="${e.target.result}" style="max-width: 200px; max-height: 200px;">`;}
       // onloadはFileReaderのプロパティの一つ。ファイルの読み込みが完了したときに呼ばれるイベントハンドラーを設定するためのもの。
       // ファイルの読み込みが成功したときに、指定された関数（ここではアロー関数）が実行される
       // 「(e) => { ... }」はアロー関数の定義。eはイベントオブジェクトで、読み込みが完了したファイルに関する情報を持っている。

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
-    <meta name="turbo-prefetch" content="false">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -15,13 +14,13 @@
     <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
     <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
 
+    <link rel="manifest" href="/manifest.json">
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
 
-    <%# Includes all stylesheet files in app/assets/stylesheets %>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
     <%= javascript_importmap_tags %>
 
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,56 +1,68 @@
 <%= form_with model: post do |f| %>
 
-<%= render 'shared/error_messages', object: f.object %>
+  <%= render 'shared/error_messages', object: f.object %>
 
 
-<%= f.label :title, t("posts.post_info.title") %>
-<%= f.text_field :title, class: "form-control" %>
+  <%= f.label :title, t("posts.post_info.title") %>
+  <%= f.text_field :title, class: "form-control" %>
 
-<div class="row">
-<%= f.label :main_image, t("posts.post_info.main_image") %>
-<%= f.file_field :main_image %>
-</div>
+  <%# ーーーーーーー画像選択でプレビューの表示のStimulus設定ーーーーーーーーー %>
 
-<div class="row">
-<%= f.label :sub_image_first, t("posts.post_info.sub_image_first") %>
-<%= f.file_field :sub_image_first %>
-</div>
+  <div class="row" data-controller="preview">
+    <%= f.label :main_image, t("posts.post_info.main_image") %>
+    <%= f.file_field :main_image, data: { "preview-target": "input", action: "change->preview#previewImage"} %>
 
-<div class="row">
-<%= f.label :sub_image_second, t("posts.post_info.sub_image_second") %>
-<%= f.file_field :sub_image_second %>
-</div>
+    <%# ーーー"change->xxxxx"のchangeは、ファイル選択の入力フィールドでユーザーがファイルを選択したときに発火するイベントーー %>
+    <%#  ーーーーー今回はchangeイベントが発火すると「preview_controller.js」の「previewImage」のメソッドが呼び出されるーーーー%>
 
-<%= f.label :source, t("posts.post_info.source") %>
-<%= f.text_field :source, class: "form-control" %>
+    <div class="row" data-preview-target="existing">
+      <%= image_tag post.main_image if post.main_image.attached? %>
+    </div>
 
-<%= f.label :store_url, t("posts.post_info.store_url") %>
-<%= f.text_field :store_url, class: "form-control" %>
+    <div class="row" data-preview-target="preview">
+    </div>
+  </div>
 
-<%= f.fields_for :dish do |dish_f| %>
-  <%= dish_f.label :introduction, t("posts.post_info.introduction") %>
-  <%= dish_f.text_area :introduction, class: "form-control" %>
+  <div class="row">
+    <%= f.label :sub_image_first, t("posts.post_info.sub_image_first") %>
+    <%= f.file_field :sub_image_first %>
+  </div>
 
-  <%= dish_f.label :description, t("posts.post_info.description") %>
-  <%= dish_f.text_area :description, class: "form-control" , rows: 9 %>
-<% end %>
+  <div class="row">
+    <%= f.label :sub_image_second, t("posts.post_info.sub_image_second") %>
+    <%= f.file_field :sub_image_second %>
+  </div>
 
+  <%= f.label :source, t("posts.post_info.source") %>
+  <%= f.text_field :source, class: "form-control" %>
 
-<h3><%= t("posts.post_info.tag_setting_info") %></h3>
+  <%= f.label :store_url, t("posts.post_info.store_url") %>
+  <%= f.text_field :store_url, class: "form-control" %>
 
-<%= label_tag :area_tag_name, t("posts.post_info.area_tag_setting") %>
-<%= text_field_tag 'post[post_area_tags_attributes][0][area_tag_attributes][name]', @area_tag_name, class: "form-control" %>
+  <%= f.fields_for :dish do |dish_f| %>
+    <%= dish_f.label :introduction, t("posts.post_info.introduction") %>
+    <%= dish_f.text_area :introduction, class: "form-control" %>
 
-<%= label_tag :genre_tag_name, t("posts.post_info.genre_tag_setting") %>
-<%= text_field_tag 'post[post_genre_tags_attributes][0][genre_tag_attributes][name]', @genre_tag_name, class: "form-control" %>
-
-<%= label_tag :taste_tag_name, t("posts.post_info.taste_tag_setting") %>
-<%= text_field_tag 'post[post_taste_tags_attributes][0][taste_tag_attributes][name]', @taste_tag_name, class: "form-control" %>
-
-<%= label_tag :outher_tag_name, t("posts.post_info.outher_tag_setting") %>
-<%= text_field_tag 'post[post_outher_tags_attributes][0][outher_tag_attributes][name]', @outher_tag_name, class: "form-control" %>
+    <%= dish_f.label :description, t("posts.post_info.description") %>
+    <%= dish_f.text_area :description, class: "form-control" , rows: 9 %>
+  <% end %>
 
 
+  <h3><%= t("posts.post_info.tag_setting_info") %></h3>
 
-<%= f.submit nil, class: "btn btn-primary" %>
+  <%= label_tag :area_tag_name, t("posts.post_info.area_tag_setting") %>
+  <%= text_field_tag 'post[post_area_tags_attributes][0][area_tag_attributes][name]', @area_tag_name, class: "form-control" %>
+
+  <%= label_tag :genre_tag_name, t("posts.post_info.genre_tag_setting") %>
+  <%= text_field_tag 'post[post_genre_tags_attributes][0][genre_tag_attributes][name]', @genre_tag_name, class: "form-control" %>
+
+  <%= label_tag :taste_tag_name, t("posts.post_info.taste_tag_setting") %>
+  <%= text_field_tag 'post[post_taste_tags_attributes][0][taste_tag_attributes][name]', @taste_tag_name, class: "form-control" %>
+
+  <%= label_tag :outher_tag_name, t("posts.post_info.outher_tag_setting") %>
+  <%= text_field_tag 'post[post_outher_tags_attributes][0][outher_tag_attributes][name]', @outher_tag_name, class: "form-control" %>
+
+
+
+  <%= f.submit nil, class: "btn btn-primary" %>
 <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -6,7 +6,7 @@
   <%= f.label :title, t("posts.post_info.title") %>
   <%= f.text_field :title, class: "form-control" %>
 
-  <%# ーーーーーーー画像選択でプレビューの表示のStimulus設定ーーーーーーーーー %>
+  <%# ーーーーーーーメイン画像選択でプレビューの表示のStimulus設定有りーーーーーーーーー %>
 
   <div class="row" data-controller="preview">
     <%= f.label :main_image, t("posts.post_info.main_image") %>
@@ -15,23 +15,47 @@
     <%# ーーー"change->xxxxx"のchangeは、ファイル選択の入力フィールドでユーザーがファイルを選択したときに発火するイベントーー %>
     <%#  ーーーーー今回はchangeイベントが発火すると「preview_controller.js」の「previewImage」のメソッドが呼び出されるーーーー%>
 
-    <div class="row" data-preview-target="existing">
-      <%= image_tag post.main_image if post.main_image.attached? %>
+    <div data-preview-target="existing">
+      <%= image_tag post.main_image.variant(resize_and_pad: [200, 200]) if post.main_image.attached? %>
     </div>
 
-    <div class="row" data-preview-target="preview">
+    <div data-preview-target="preview">
     </div>
   </div>
 
-  <div class="row">
+  <%# ーーーーーーーーーーーーーーーーーーーー %>
+
+  <%# ーーーーーーーサブ画像1選択でプレビューの表示のStimulus設定有りーーーーーーーーー %>
+
+  <div class="row" data-controller="preview">
     <%= f.label :sub_image_first, t("posts.post_info.sub_image_first") %>
-    <%= f.file_field :sub_image_first %>
+    <%= f.file_field :sub_image_first, data: { "preview-target": "input", action: "change->preview#previewImage"} %>
+
+    <div data-preview-target="existing">
+      <%= image_tag post.sub_image_first.variant(resize_and_pad: [200, 200]) if post.sub_image_first.attached? %>
+    </div>
+
+    <div data-preview-target="preview">
+    </div>
   </div>
 
-  <div class="row">
+  <%# ーーーーーーーーーーーーーーーーーーーーー %>
+
+  <%# ーーーーーーーサブ画像2選択でプレビューの表示のStimulus設定有りーーーーーーーーー %>
+
+  <div class="row" data-controller="preview">
     <%= f.label :sub_image_second, t("posts.post_info.sub_image_second") %>
-    <%= f.file_field :sub_image_second %>
+    <%= f.file_field :sub_image_second, data: { "preview-target": "input", action: "change->preview#previewImage"} %>
+
+    <div data-preview-target="existing">
+      <%= image_tag post.sub_image_second.variant(resize_and_pad: [200, 200]) if post.sub_image_second.attached? %>
+    </div>
+
+    <div data-preview-target="preview">
+    </div>
   </div>
+
+  <%# ーーーーーーーーーーーーーーーーーーーーー %>
 
   <%= f.label :source, t("posts.post_info.source") %>
   <%= f.text_field :source, class: "form-control" %>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -8,9 +8,6 @@
         <div class="row">
           <%= link_to t(".to_login_page"), login_path %>
         </div>
-        <div class="row">
-          <%= link_to "@googleでログインする", auth_at_provider_path(provider: :google) %>
-        </div>
       <% end %>
     </div>
   </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -14,6 +14,8 @@
       <%= f.submit t('.login'), class: "btn btn-primary" %>
     <% end %>
 
+    <%# ---------↓googleログイン部分--------- %>
+
     <hr class="my-4">
 
     <div class="d-flex justify-content-center">
@@ -33,6 +35,8 @@
     </div>
 
     <hr class="my-4">
+
+    <%# ---------googleログイン部分--------- %>
 
     <div class='text-center'>
       <%= link_to t(".to_register_page"), new_user_path %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -86,6 +86,8 @@
 
       <hr class="my-4">
 
+      <%# ---------googleログイン部分--------- %>
+
       <div class='text-center'>
         <%= link_to t(".to_login_page"), login_path %>
         <%= link_to t(".to_top_page"), root_path %>


### PR DESCRIPTION
概要
---
Post(記事)作成、編集時に画像をプレビューで見れるようにする

内容
---
- [x] app/javascript/controllers/index.js
・新たに作成したpreview_controller.jsの情報を記入。

- [x] app/javascript/controllers/preview_controller.js
・新たにStimulusのコントローラーのpreview_controller.jsを作成。
Post（記事）の作成などで画像を選択したときに画像をプレビューで確認できるようにする。

- [x] app/views/layouts/application.html.erb
・設定をやや変更。

- [x] app/views/posts/_form.html.erb
・プレビュー表示の設定を追加。

- [x] app/views/static_pages/top.html.erb
・消し忘れだったので削除。

- [x] Dockerfile.dev
・cronパッケージは使用予定を変更したので削除。

- [x] デプロイ成功画面を確認する。
