### PR TITLE
タグ検索結果ページのページネーション修正

### DIFF
--- a/app/controllers/searchs_controller.rb
+++ b/app/controllers/searchs_controller.rb
@@ -10,28 +10,18 @@ class SearchsController < ApplicationController
     @taste_posts = Post.joins(:taste_tags).where(taste_tags: { name: @taste_tags })
     @outher_posts = Post.joins(:outher_tags).where(outher_tags: { name: @outher_tags })
 
+    @post_ids = @area_posts.pluck(:id) + @genre_posts.pluck(:id) + @taste_posts.pluck(:id) + @outher_posts.pluck(:id)
+
     if params[:latest]
-      @search_posts = (@area_posts + @genre_posts + @taste_posts + @outher_posts).uniq.sort_by(&:created_at)
+      @search_posts = Post.where(id: @post_ids).order(created_at: :desc).page(params[:page]).per(3)
     elsif params[:old]
-      @search_posts = (@area_posts + @genre_posts + @taste_posts + @outher_posts).uniq.sort_by(&:created_at).reverse
+      @search_posts = Post.where(id: @post_ids).order(created_at: :asc).page(params[:page]).per(3)
     else
-      @search_posts = (@area_posts + @genre_posts + @taste_posts + @outher_posts).uniq
+      @search_posts = Post.where(id: @post_ids).page(params[:page]).per(3)
     end
     # 簡略化用メソッドを実装したい。現在NoMethodErrorで未実装。記事一覧と同様処理で行けそう
 
     @post_path = "3"
-
-    # -------------ページネーション(gemなし)-----------------
-
-    @max_page = 18
-    @page = params[:page].to_i > 0 ? params[:page].to_i : 1
-    # animals_path(page: 1)みたいにしなくてもpageは1になる
-    # @eがnilでもnil.to_iは0になる
-    @paginate_search_posts = @search_posts.slice((@page - 1) * @max_page, @max_page)
-    # @paginate_search_posts は記事情報が入る
-    @total_posts = @search_posts.count
-    # sizeとcountは動作はにてる
-    @total_pages = (@total_posts.to_f / @max_page).ceil
 
     # ----------------------おすすめ表示--------------------------
 

--- a/app/javascript/controllers/preview_controller.js
+++ b/app/javascript/controllers/preview_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
     const existing = this.existingTarget
     const files = input.files   
     // HTMLの<input type="file">要素から選択されたファイルの配列を取得できる
-    // 直接ビューに<input type="file">はないが「form.file_field :avatar」がそれを生成するRailsのヘルパーメソッド
+    // 直接ビューに<input type="file">はないが「form.file_field :main_image」がそれを生成するRailsのヘルパーメソッド
 
     if (existing) {existing.style.display = 'none';}
     // 編集時、既存の画像は初期表示。この処理で非表示にする。

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
+    <meta name="turbo-prefetch" content="false">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/searchs/index.html.erb
+++ b/app/views/searchs/index.html.erb
@@ -5,7 +5,7 @@
 <div class="row">
 
 
-<% if @paginate_search_posts.present? %>
+<% if @search_posts.present? %>
   <div class="d-flex">
     <h3><%= t(".search_results") %></h3>
     <h1 class="ms-auto">
@@ -20,19 +20,11 @@
     </h1>
   </div>
 
-  <% @paginate_search_posts.each do |post| %>
+  <% @search_posts.each do |post| %>
     <%= render "post_image", post: post %>
   <% end %>
 
-
-
-  <% if @page > 1 %>
-    <%= link_to '@@@前へ', searchs_path(page: @page - 1, area_tags: @area_tags, genre_tags: @genre_tags, taste_tags: @taste_tags, outher_tags: @outher_tags) %>
-  <% end %>
-
-  <% if @page < @total_pages %>
-    <%= link_to '@@@次へ', searchs_path(page: @page + 1, area_tags: @area_tags, genre_tags: @genre_tags, taste_tags: @taste_tags, outher_tags: @outher_tags) %>
-  <% end %>
+  <%= paginate @search_posts, theme: "bootstrap-5" %>
 
 
   <% if @recommendations.present? %>


### PR DESCRIPTION
概要
---
・タグ検索結果ページのページネーションを修正

内容
---
- [x] app/views/layouts/application.html.erb
・マウスオーバー時にリンク先をプリフェッチする挙動が再度確認できたので再修正。

- [x] app/javascript/controllers/preview_controller.js
・説明文を修正。

- [x] app/controllers/searchs_controller.rb
・タグ検索結果にgem'kaminari'を使用したページネーションが以前はうまくいかなかったので、gemを使用しないページネーションを暫定で導入していましたが、gem'kaminari'を使用したページネーションが今回うまく実装できたのでそちらに変更します。

- [x] app/views/searchs/index.html.erb
・gem'kaminari'を使用したページネーションが実装成功したことにより、gemを使用しない以前のページネーション部分を削除、変更。

- [x] デプロイ成功画面を確認する。