### PR TITLE
google map APIを用いたマップ機能追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,9 @@ gem "ransack"
 gem "dotenv-rails"
 # 開発環境"のみ"で.envファイルを用いて環境変数を扱えるようにする
 
+gem "geocoder"
+# 地名を緯度経度に変換
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,9 @@ gem "dotenv-rails"
 gem "geocoder"
 # 地名を緯度経度に変換
 
+gem "google_places"
+# google Place APIを使用するときに使う
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,9 @@ gem "meta-tags"
 gem "ransack"
 # 検索機能に使用
 
+gem "dotenv-rails"
+# 開発環境"のみ"で.envファイルを用いて環境変数を扱えるようにする
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
+    csv (3.3.4)
     date (3.4.1)
     debug (1.10.0)
       irb (~> 1.10)
@@ -176,6 +177,9 @@ GEM
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
+    geocoder (1.8.5)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     gretel (5.0.1)
@@ -561,6 +565,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  geocoder
   gretel
   image_processing
   importmap-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,10 +182,16 @@ GEM
       csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google_places (2.0.0)
+      httparty (>= 0.13.1)
     gretel (5.0.1)
       actionview (>= 6.1)
       railties (>= 6.1)
     hashie (5.0.0)
+    httparty (0.23.1)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
@@ -566,6 +572,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   geocoder
+  google_places
   gretel
   image_processing
   importmap-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,9 @@ GEM
     dockerfile-rails (1.7.9)
       rails (>= 3.0.0)
     dotenv (3.1.7)
+    dotenv-rails (3.1.7)
+      dotenv (= 3.1.7)
+      railties (>= 6.1)
     drb (2.2.1)
     ed25519 (1.3.0)
     erubi (1.13.1)
@@ -555,6 +558,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   dockerfile-rails (>= 1.6)
+  dotenv-rails
   factory_bot_rails
   faker
   gretel

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -56,16 +56,16 @@ class PostsController < ApplicationController
     if logged_in? && current_user.address != nil && current_user.address != ""
       @map_center_latitude = current_user.latitude
       @map_center_longitude = current_user.longitude
-      @client = GooglePlaces::Client.new(ENV['GOOGLE_MAPS_API_KEY'])
-      @store = @client.spots(@map_center_latitude, @map_center_longitude, :name => @post.title, :radius => 2500, :language => 'ja')
+      @client = GooglePlaces::Client.new(ENV["GOOGLE_MAPS_API_KEY"])
+      @store = @client.spots(@map_center_latitude, @map_center_longitude, name: @post.title, radius: 2500, language: "ja")
       # google_placesで店舗の検索を行う。
       # @map_center_latitude, @map_center_longitudeでマップ中心を決める。
       # nameで単語検索。radiusで検索する範囲（半径/m）を指定。languageで日本語で情報を取得。
     else
       @map_center_latitude = 35.6803997   # 東京の緯度
       @map_center_longitude = 139.7690174   # 東京の経度
-      @client = GooglePlaces::Client.new(ENV['GOOGLE_MAPS_API_KEY'])
-      @store = @client.spots(35.6803997, 139.7690174, :name => I18n.t('controller.posts.map_search_target'), :radius => 2500, :language => 'ja')
+      @client = GooglePlaces::Client.new(ENV["GOOGLE_MAPS_API_KEY"])
+      @store = @client.spots(35.6803997, 139.7690174, name: I18n.t("controller.posts.map_search_target"), radius: 2500, language: "ja")
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -58,11 +58,14 @@ class PostsController < ApplicationController
       @map_center_longitude = current_user.longitude
       @client = GooglePlaces::Client.new(ENV['GOOGLE_MAPS_API_KEY'])
       @store = @client.spots(@map_center_latitude, @map_center_longitude, :name => @post.title, :radius => 2500, :language => 'ja')
+      # google_placesで店舗の検索を行う。
+      # @map_center_latitude, @map_center_longitudeでマップ中心を決める。
+      # nameで単語検索。radiusで検索する範囲（半径/m）を指定。languageで日本語で情報を取得。
     else
       @map_center_latitude = 35.6803997   # 東京の緯度
       @map_center_longitude = 139.7690174   # 東京の経度
       @client = GooglePlaces::Client.new(ENV['GOOGLE_MAPS_API_KEY'])
-      @store = @client.spots(35.6803997, 139.7690174, :name => '味噌カレー牛乳ラーメン', :radius => 2500, :language => 'ja')
+      @store = @client.spots(35.6803997, 139.7690174, :name => I18n.t('controller.posts.map_search_target'), :radius => 2500, :language => 'ja')
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -53,8 +53,17 @@ class PostsController < ApplicationController
       current_user.view_history_plus(@post)
     end
 
-    @client = GooglePlaces::Client.new(ENV['GOOGLE_MAPS_API_KEY'])
-    @store = @client.spots(35.6803997, 139.7690174, :name => '味噌カレー牛乳ラーメン', :language => 'ja')
+    if logged_in? && current_user.address != nil && current_user.address != ""
+      @map_center_latitude = current_user.latitude
+      @map_center_longitude = current_user.longitude
+      @client = GooglePlaces::Client.new(ENV['GOOGLE_MAPS_API_KEY'])
+      @store = @client.spots(@map_center_latitude, @map_center_longitude, :name => '味噌カレー牛乳ラーメン', :language => 'ja')
+    else
+      @map_center_latitude = 35.6803997   # 東京の緯度
+      @map_center_longitude = 139.7690174   # 東京の経度
+      @client = GooglePlaces::Client.new(ENV['GOOGLE_MAPS_API_KEY'])
+      @store = @client.spots(35.6803997, 139.7690174, :name => '味噌カレー牛乳ラーメン', :language => 'ja')
+    end
   end
 
   def edit

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -57,12 +57,12 @@ class PostsController < ApplicationController
       @map_center_latitude = current_user.latitude
       @map_center_longitude = current_user.longitude
       @client = GooglePlaces::Client.new(ENV['GOOGLE_MAPS_API_KEY'])
-      @store = @client.spots(@map_center_latitude, @map_center_longitude, :name => '味噌カレー牛乳ラーメン', :language => 'ja')
+      @store = @client.spots(@map_center_latitude, @map_center_longitude, :name => @post.title, :radius => 2500, :language => 'ja')
     else
       @map_center_latitude = 35.6803997   # 東京の緯度
       @map_center_longitude = 139.7690174   # 東京の経度
       @client = GooglePlaces::Client.new(ENV['GOOGLE_MAPS_API_KEY'])
-      @store = @client.spots(35.6803997, 139.7690174, :name => '味噌カレー牛乳ラーメン', :language => 'ja')
+      @store = @client.spots(35.6803997, 139.7690174, :name => '味噌カレー牛乳ラーメン', :radius => 2500, :language => 'ja')
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -52,6 +52,9 @@ class PostsController < ApplicationController
       end
       current_user.view_history_plus(@post)
     end
+
+    @client = GooglePlaces::Client.new(ENV['GOOGLE_MAPS_API_KEY'])
+    @store = @client.spots(35.6803997, 139.7690174, :name => '味噌カレー牛乳ラーメン', :language => 'ja')
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,6 +28,12 @@ class UsersController < ApplicationController
     @user = current_user
     @avatar = user_params[:avatar]
 
+    result = Geocoder.search(@user.address).first
+    if result
+      @user.latitude = result.latitude
+      @user.longitude = result.longitude
+    end
+
     if user_params[:name].present? && user_params[:email].present?
       unless @avatar.nil?
         @user.avatar.purge
@@ -52,6 +58,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation, :is_public, :introduction, :agree_terms, :avatar)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :is_public, :introduction, :address, :agree_terms, :avatar)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,12 @@ class User < ApplicationRecord
 
   attr_accessor :agree_terms
 
+  geocoded_by :address
+  # addressカラムの内容を緯度・経度に変換する
+
+  after_validation :geocode
+  # バリデーションの実行後に変換処理を実行後、latitudeカラム・longitudeカラムに緯度・経度の値が入力される
+
   def agreement
     if new_record?
       unless agree_terms == "1" || agree_terms == true

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -184,19 +184,21 @@
 <script>
   // 地図を初期化する関数
   function initMap() {
-    // 地図のオプション
     const mapOptions = {
-      center: { lat: 35.6803997, lng: 139.7690174 },
+      center: { lat: <%= @map_center_latitude %>, lng: <%= @map_center_longitude %> },
+      // 地図の中心を決める
       zoom: 14
+      // 地図の初期の倍率を指定
     };
 
-    // 地図を指定した要素に表示
     const map = new google.maps.Map(document.getElementById('map'), mapOptions);
+    // 地図を指定した要素に表示
 
     <% @store.each_with_index do |store, i| %>
 
       contentString_<%= i %> = 
       '<div><%= store.name %></div>';
+      // マーカーをクリックしたときの表示項目
 
       infowindow_<%= i %> = new google.maps.InfoWindow({
         content: contentString_<%= i %>,
@@ -207,6 +209,7 @@
         position: { lat: <%= store.lat %>, lng: <%= store.lng %> },
         map: map
       });
+      // マーカーの表示位置
 
       marker_<%= i %>.addListener("click", () => {
         infowindow_<%= i %>.open({
@@ -214,6 +217,7 @@
           map,
         });
       });
+      // マーカーをクリックしたときの処理
 
     <% end %>
   }

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -149,28 +149,25 @@
 
   <% if !logged_in? %>
     <div class="mt-3">
-      ログインするとこの料理が提供されている近隣店舗を調べることができます
+      <%= t(".not_login_description") %>
     </div>
     <div>
-      例  出身地「東京」  料理名「味噌カレー牛乳ラーメン」の場合
+      <%= t(".search_example") %>
     </div>
   <% elsif logged_in? && current_user.address != nil && current_user.address != "" && @store.length != 0 %>
     <div class="mt-3">
-      こちらの店舗で提供されている可能性があります
+      <%= t(".google_map_description") %>
     </div>
   <% elsif current_user.address == nil || current_user.address == "" %>
     <div class="mt-3">
-      出身地が設定されてません
+      <%= t(".not_address_description") %>
     </div>
     <div>
-      設定するとこの料理が提供されている近隣店舗を調べることができます
-    </div>
-    <div>
-      例  出身地「東京」  料理名「味噌カレー牛乳ラーメン」の場合
+      <%= t(".search_example") %>
     </div>
   <% elsif @store.length == 0 %>
     <div class="mt-3">
-      あなたの近隣ではこの料理が提供されている店舗は見つかりませんでした
+      <%= t(".not_found_description") %>
     </div>
   <% end %>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -4,152 +4,182 @@
 
 
 <div class="container">
-<div class="row">
-  <%= @post.title %>
-</div>
+  <div class="row">
+    <%= @post.title %>
+  </div>
 
-<div class="row">
-  <% @post.area_tags.each do |area_tag| %>
-    <%= area_tag.name %>
+  <div class="row">
+    <% @post.area_tags.each do |area_tag| %>
+      <%= area_tag.name %>
+    <% end %>
+    <% @post.genre_tags.each do |genre_tag| %>
+      <%= genre_tag.name %>
+    <% end %>
+    <% @post.taste_tags.each do |taste_tag| %>
+      <%= taste_tag.name %>
+    <% end %>
+    <% @post.outher_tags.each do |outher_tag| %>
+      <%= outher_tag.name %>
+    <% end %>
+  </div>
+
+  <div class="d-flex flex-row">
+    <div><%= t(".posted_by") %></div>
+    <div><%= link_to @posted_user.name, user_path(@posted_user) %></div>
+  </div>
+
+  <div class="row">
+    <% if @post.source.present? %>
+      <%= t(".source", post_source: @post.source) %>
+    <% end %>
+  </div>
+
+  <div class="row">
+    <% if @post.store_url.present? %>
+      <%= t(".store_url", post_store_url: @post.store_url) %>
+    <% end %>
+  </div>
+
+  <%# -----------------------画像関連-------------------------- %>
+
+  <div class="d-flex justify-content-center">
+
+  <div class="row mb-2">
+  <% if @post.main_image.attached? %>
+    <%= image_tag @post.main_image.variant(resize_to_fit: [600, 600]) %>
   <% end %>
-  <% @post.genre_tags.each do |genre_tag| %>
-    <%= genre_tag.name %>
-  <% end %>
-  <% @post.taste_tags.each do |taste_tag| %>
-    <%= taste_tag.name %>
-  <% end %>
-  <% @post.outher_tags.each do |outher_tag| %>
-    <%= outher_tag.name %>
-  <% end %>
-</div>
+  </div>
 
-<div class="d-flex flex-row">
-  <div><%= t(".posted_by") %></div>
-  <div><%= link_to @posted_user.name, user_path(@posted_user) %></div>
-</div>
-
-<div class="row">
-  <% if @post.source.present? %>
-    <%= t(".source", post_source: @post.source) %>
-  <% end %>
-</div>
-
-<div class="row">
-  <% if @post.store_url.present? %>
-    <%= t(".store_url", post_store_url: @post.store_url) %>
-  <% end %>
-</div>
-
-<%# -----------------------画像関連-------------------------- %>
-
-<div class="d-flex justify-content-center">
-
-<div class="row mb-2">
-<% if @post.main_image.attached? %>
-  <%= image_tag @post.main_image.variant(resize_to_fit: [600, 600]) %>
-<% end %>
-</div>
-
-</div>
+  </div>
 
 
-<div class="d-flex justify-content-center align-items-start">
+  <div class="d-flex justify-content-center align-items-start">
 
-<div class="row">
-  <% if @post.sub_image_first.attached? %>
-    <%= image_tag @post.sub_image_first.variant(resize_to_fit: [400, 400]) %>
-  <% end %>
-</div>
-
-<div class="col-1">
-</div>
-
-<div class="row">
-  <% if @post.sub_image_second.attached? %>
-    <%= image_tag @post.sub_image_second.variant(resize_to_fit: [400, 400]) %>
-  <% end %>
-</div>
-
-</div>
-
-<div class="row">
-<%= @post.dish.description %>
-</div>
-
-
-<%# --------------------プレイリスト関連--------------------- %>
-
-<% if logged_in? %>
-<div class="col-2">
-<button type="button" class="btn btn-primary mb-12 btn-sm" data-toggle="modal" data-target="#playlist">プレイリストへ追加</button>
-</div>
-
-<div class="modal fade" id="playlist" tabindex="-1">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h4><div class="modal-title" id="myModalLabel">@プレイリストへ追加</h4>
-      </div>
-
-      <div class="modal-body">
-      <%= form_with(url: add_to_playlist_post_path(@post), method: :post) do %>
-        <%= label_tag :playlist_id, "@作成済みのプレイリストを選択" %>
-        <%= select_tag :playlist_id, options_from_collection_for_select(@user_playlists, :id, :title), include_blank: true %>
-        <%= submit_tag "選択" %>
+    <div class="row">
+      <% if @post.sub_image_first.attached? %>
+        <%= image_tag @post.sub_image_first.variant(resize_to_fit: [400, 400]) %>
       <% end %>
-      </div>
+    </div>
 
-      <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">@閉じる</button>
-      </div>
+    <div class="col-1">
+    </div>
+
+    <div class="row">
+      <% if @post.sub_image_second.attached? %>
+        <%= image_tag @post.sub_image_second.variant(resize_to_fit: [400, 400]) %>
+      <% end %>
+    </div>
+
+  </div>
+
+  <div class="row">
+    <%= @post.dish.description %>
+  </div>
+
+
+    <%# --------------------プレイリスト関連--------------------- %>
+
+    <% if logged_in? %>
+    <div class="col-2">
+    <button type="button" class="btn btn-primary mb-12 btn-sm" data-toggle="modal" data-target="#playlist">プレイリストへ追加</button>
+    </div>
+
+    <div class="modal fade" id="playlist" tabindex="-1">
+    <div class="modal-dialog">
+    <div class="modal-content">
+    <div class="modal-header">
+    <h4><div class="modal-title" id="myModalLabel">@プレイリストへ追加</h4>
+    </div>
+
+    <div class="modal-body">
+    <%= form_with(url: add_to_playlist_post_path(@post), method: :post) do %>
+    <%= label_tag :playlist_id, "@作成済みのプレイリストを選択" %>
+    <%= select_tag :playlist_id, options_from_collection_for_select(@user_playlists, :id, :title), include_blank: true %>
+    <%= submit_tag "選択" %>
+    <% end %>
+    </div>
+
+    <div class="modal-footer">
+    <button type="button" class="btn btn-default" data-dismiss="modal">@閉じる</button>
+    </div>
 
     </div>
-  </div>
-</div>
-<% end %>
-
-
-<%# -------------いいね機能関連---------------------- %>
-
-<% if logged_in? && @post.user_id != current_user.id %>
-  <% if current_user.like_include?(@post) %>
-
-    <%= link_to post_like_path(@post), id: "bad-#{@post.id}", data: { turbo_method: :delete } do %>
-      <i class="bi bi-hand-thumbs-up-fill"></i>
-    <% end %>
-
-  <% else %>
-
-    <%= link_to post_likes_path(post_id: @post.id), id: "good-#{@post.id}", data: { turbo_method: :post } do %>
-      <i class="bi bi-hand-thumbs-up"></i>
+    </div>
+    </div>
     <% end %>
 
 
-  <% end %>
-<% end %>
+  <%# -------------いいね機能関連---------------------- %>
+
+  <% if logged_in? && @post.user_id != current_user.id %>
+    <% if current_user.like_include?(@post) %>
+
+      <%= link_to post_like_path(@post), id: "bad-#{@post.id}", data: { turbo_method: :delete } do %>
+        <i class="bi bi-hand-thumbs-up-fill"></i>
+      <% end %>
+
+    <% else %>
+
+      <%= link_to post_likes_path(post_id: @post.id), id: "good-#{@post.id}", data: { turbo_method: :post } do %>
+        <i class="bi bi-hand-thumbs-up"></i>
+      <% end %>
 
 
-<%# ------------コメント関連------------ %>
-<% if logged_in? %>
-  <%= render "comments/form", comment: @comment, post: @post %>
-<% end %>
-
-<%= turbo_frame_tag "limit_comments" do %>
-  <% @post_comments.each do |comment| %>
-    <%= render "comments/comment", comment: comment %>
-  <% end %>
-  <% if @post_comments.present? %>
-    <%= turbo_frame_tag "show_all" do %>
-       <%= link_to "すべて表示する(あとでアイコン化)", replace_all_comments_post_comments_path(post_id: @post.id) %>
     <% end %>
   <% end %>
-<% end %>
 
+
+  <%# ------------コメント関連------------ %>
+  <% if logged_in? %>
+    <%= render "comments/form", comment: @comment, post: @post %>
+  <% end %>
+
+  <%= turbo_frame_tag "limit_comments" do %>
+    <% @post_comments.each do |comment| %>
+      <%= render "comments/comment", comment: comment %>
+    <% end %>
+    <% if @post_comments.present? %>
+      <%= turbo_frame_tag "show_all" do %>
+         <%= link_to "すべて表示する(あとでアイコン化)", replace_all_comments_post_comments_path(post_id: @post.id) %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%# ---------------google map関連-------------- %>
+
+  <% if !logged_in? %>
+    <div class="mt-3">
+      ログインするとこの料理が提供されている近隣店舗を調べることができます
+    </div>
+    <div>
+      例  出身地「東京」  料理名「味噌カレー牛乳ラーメン」の場合
+    </div>
+  <% elsif logged_in? && current_user.address != nil && current_user.address != "" && @store.length != 0 %>
+    <div class="mt-3">
+      こちらの店舗で提供されている可能性があります
+    </div>
+  <% elsif current_user.address == nil || current_user.address == "" %>
+    <div class="mt-3">
+      出身地が設定されてません
+    </div>
+    <div>
+      設定するとこの料理が提供されている近隣店舗を調べることができます
+    </div>
+    <div>
+      例  出身地「東京」  料理名「味噌カレー牛乳ラーメン」の場合
+    </div>
+  <% elsif @store.length == 0 %>
+    <div class="mt-3">
+      あなたの近隣ではこの料理が提供されている店舗は見つかりませんでした
+    </div>
+  <% end %>
+
+  <div class="mt-3" id="map" style="height: 600px;"></div>
 
 </div> 
 
 
-<div id="map" style="height: 600px;"></div>
+
 
 <script>
   // 地図を初期化する関数
@@ -157,7 +187,7 @@
     // 地図のオプション
     const mapOptions = {
       center: { lat: 35.6803997, lng: 139.7690174 },
-      zoom: 13
+      zoom: 14
     };
 
     // 地図を指定した要素に表示

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -151,7 +151,7 @@
     <div class="mt-3">
       <%= t(".not_login_description") %>
     </div>
-    <div>
+    <div class="mt-3">
       <%= t(".search_example") %>
     </div>
   <% elsif logged_in? && current_user.address != nil && current_user.address != "" && @store.length != 0 %>
@@ -162,7 +162,7 @@
     <div class="mt-3">
       <%= t(".not_address_description") %>
     </div>
-    <div>
+    <div class="mt-3">
       <%= t(".search_example") %>
     </div>
   <% elsif @store.length == 0 %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -203,6 +203,7 @@
       infowindow_<%= i %> = new google.maps.InfoWindow({
         content: contentString_<%= i %>,
       });
+      // マーカーをクリックしたときに表示される情報ウィンドウを作成している
 
 
       marker_<%= i %> = new google.maps.Marker({
@@ -218,6 +219,7 @@
         });
       });
       // マーカーをクリックしたときの処理
+      // anchorは情報ウィンドウがどのマーカーに対して表示されるかを指定している
 
     <% end %>
   }

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -147,4 +147,45 @@
 
 
 </div> 
-<%# 4行のcontainer %>
+
+
+<div id="map" style="height: 600px;"></div>
+
+<script>
+  // 地図を初期化する関数
+  function initMap() {
+    // 地図のオプション
+    const mapOptions = {
+      center: { lat: 35.6803997, lng: 139.7690174 },
+      zoom: 13
+    };
+
+    // 地図を指定した要素に表示
+    const map = new google.maps.Map(document.getElementById('map'), mapOptions);
+
+    <% @store.each_with_index do |store, i| %>
+
+      contentString_<%= i %> = 
+      '<div><%= store.name %></div>';
+
+      infowindow_<%= i %> = new google.maps.InfoWindow({
+        content: contentString_<%= i %>,
+      });
+
+
+      marker_<%= i %> = new google.maps.Marker({
+        position: { lat: <%= store.lat %>, lng: <%= store.lng %> },
+        map: map
+      });
+
+      marker_<%= i %>.addListener("click", () => {
+        infowindow_<%= i %>.open({
+          anchor: marker_<%= i %>,
+          map,
+        });
+      });
+
+    <% end %>
+  }
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAPS_API_KEY"] %>&callback=initMap"></script>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -35,6 +35,11 @@
           <%= f.text_field :introduction, class: "form-control" %>
         </div>
 
+        <div class="mb-3">
+          <%= f.label :address, t(".address"), class: "form-label" %>
+          <%= f.text_field :address, class: "form-control" %>
+        </div>
+
         <div class="row mb-3">
           <%= f.label :avatar, t(".avatar") %>
           <%= f.file_field :avatar %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,8 +23,6 @@
   <% if @user == current_user %>
     <div class="mt-2">
       <%= @user.address %>
-      <%= @user.latitude %>
-      <%= @user.longitude %>
     </div>
   <% end %>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -20,6 +20,14 @@
     <% end %>
   </div>
 
+  <% if @user == current_user %>
+    <div class="mt-2">
+      <%= @user.address %>
+      <%= @user.latitude %>
+      <%= @user.longitude %>
+    </div>
+  <% end %>
+
   <% if @user.is_public || @user == current_user %>
     <div class="mt-2">
       <%= t(".introduction", introduction: @user.introduction) %>

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -7,7 +7,7 @@ Geocoder.configure(
   use_https: true,           # use HTTPS for lookup requests? (if supported)
   # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
   # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
-  api_key: ENV['GOOGLE_MAPS_API_KEY'],                # API key for geocoding service
+  api_key: ENV["GOOGLE_MAPS_API_KEY"],                # API key for geocoding service
   # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
 
   # Exceptions that should not be rescued by default

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,27 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  lookup: :google,       # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  use_https: true,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  api_key: ENV['GOOGLE_MAPS_API_KEY'],                # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+)

--- a/config/locales/view_connection/ja.yml
+++ b/config/locales/view_connection/ja.yml
@@ -85,7 +85,7 @@ ja:
       email_required: メールアドレス(必須)?
       password_required: パスワード(必須)?
       password_confirmation_required: パスワード再確認(必須)？
-      is_public: 公開設定（必須）?
+      is_public: 公開設定?
       permit: 許可？
       not_permit: 不許可?
       accept_terms_of_use: 利用規約に同意しますか？(必須)？？？？

--- a/config/locales/view_connection/ja.yml
+++ b/config/locales/view_connection/ja.yml
@@ -188,3 +188,6 @@ ja:
       source: "出典: %{post_source}????"
       store_url: "店舗情報: %{post_store_url}???"
       whose_comment: "%{user_name}さんのコメント???"
+  controller:
+    posts:
+      map_search_target: "味噌カレー牛乳ラーメン"

--- a/config/locales/view_connection/ja.yml
+++ b/config/locales/view_connection/ja.yml
@@ -188,6 +188,11 @@ ja:
       source: "出典: %{post_source}????"
       store_url: "店舗情報: %{post_store_url}???"
       whose_comment: "%{user_name}さんのコメント???"
+      not_login_description: "ログインすると料理が提供されている近隣店舗を調べることができます??"
+      search_example: "例  出身地「東京」  料理名「味噌カレー牛乳ラーメン」の場合??"
+      google_map_description: "こちらの店舗で提供されている可能性があります??"
+      not_address_description: "出身地が設定されてません。設定すると料理が提供されている近隣店舗を調べることができます??"
+      not_found_description: "あなたの近隣ではこの料理が提供されている店舗は見つかりませんでした??"
   controller:
     posts:
       map_search_target: "味噌カレー牛乳ラーメン"

--- a/config/locales/view_connection/ja.yml
+++ b/config/locales/view_connection/ja.yml
@@ -113,6 +113,7 @@ ja:
       password_required: パスワードの変更?
       password_confirmation_required: パスワード変更時の再確認？
       introduction: 自己紹介？？
+      address: 所在地??
       avatar: アバター設定？？
       is_public: 公開設定?
       permit: 許可？

--- a/db/migrate/20250416121833_add_address_to_users.rb
+++ b/db/migrate/20250416121833_add_address_to_users.rb
@@ -1,0 +1,7 @@
+class AddAddressToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :address, :text
+    add_column :users, :latitude, :float
+    add_column :users, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_30_090918) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_16_121833) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -179,6 +179,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_30_090918) do
     t.datetime "reset_password_token_expires_at"
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
+    t.text "address"
+    t.float "latitude"
+    t.float "longitude"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end


### PR DESCRIPTION
概要
---
・google map APIを用いたマップ機能追加

内容
---
- [x] Gemfile
・開発環境で.envファイルを用いて環境変数を扱えるようにするため、gem "dotenv-rails"をインストール。
・地名を緯度経度に変換しgoogle map APIで使用するため、gem "geocoder"をインストール。
・google Place APIで店舗情報を取得するために、gem "google_places"をインストール。

- [x] db/migrate/20250416121833_add_address_to_users.rb
・User（ユーザー）テーブルに新たにaddress（所在地）カラム、latitude（緯度）カラム、longitude（経度）カラムを追加。

- [x] config/initializers/geocoder.rb
・geocorder APIの設定ファイルを追加。

- [x] config/locales/view_connection/ja.yml
・新たに対応する言語を追加。


- [x] app/models/user.rb
・geocorder APIを用いて、address（所在地）カラムの情報をlatitude（緯度）カラム、longitude（経度）カラムに変換する処理を追加。


- [x] app/controllers/posts_controller.rb
・google place APIで店舗情報を取得する設定を追加。ユーザーのログインの状態やaddress（所在地）カラムが入力されているかなどで場合分けをします。

条件がtrueの場合の説明をします。
ユーザーのlatitude（緯度）カラム、longitude（経度）カラムをもとに、マップ中心地（初期位置）を決めます。
次に@clientにgoogle place APIを使用するためのクライアント作成し代入します。
そして店舗検索を行います。その際の条件として、まずマップ中心地（初期位置）周辺の店舗の検索設定をします。
次に@post.title（ビューで開いている記事のタイトル）で検索をします。
radius（マップでの半径）は2500mに設定。
取得する際に言語は日本語になるようにします。

続いて条件がfalseの場合の説明をします。
こちらは、ユーザーが非ログインであったり、まだaddress（所在地）カラムが未設定でgoogle mapで店舗検索することができません。
その状態でも最低限使用感を感じてもらえるようにしました。
まず、固定の場所をマップ中心地（初期位置）に決めます。場所は東京の緯度経度にしました。
こちらでも@clientにgoogle place APIを使用するためのクライアント作成し代入します。
上記で設定した東京の緯度経度を中心に店舗検索をします。
検索する単語も固定値（今回は「味噌カレー牛乳ラーメン」としてみました）にします。
半径や言語設定はtrueの場合と同じです。

- [x] app/controllers/users_controller.rb
・geocorder APIを用いて、address（所在地）カラムの情報をlatitude（緯度）カラム、longitude（経度）カラムに変換する処理を追加。

- [x] app/views/posts/show.html.erb
・google mapを表示するためのコードを追加。
・google mapを表示するためのjavascriptを追加。
google place APIで店舗検索をし該当する店舗が存在する場合、対象にマーカーを表示します。

- [x] app/views/users/edit.html.erb
・アカウント編集画面でaddress（所在地）を編集できるようにする。

- [x] app/views/users/show.html.erb
・ユーザー詳細画面にaddress（所在地）を追加。

- [x] デプロイ成功画面を確認。