### PR TITLE
Postテーブルにカラム追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -169,6 +169,6 @@ class PostsController < ApplicationController
   private
 
   def post_params
-    params.require(:post).permit(:id, :title, :source, :store_url, :main_image, :sub_image_first, :sub_image_second, dish_attributes: [ :id, :introduction, :description ], post_area_tags_attributes: [ :id, area_tag_attributes: [ :id, :name ] ], post_genre_tags_attributes: [ :id, genre_tag_attributes: [ :id, :name ] ], post_taste_tags_attributes: [ :id, taste_tag_attributes: [ :id, :name ] ], post_outher_tags_attributes: [ :id, outher_tag_attributes: [ :id, :name ] ])
+    params.require(:post).permit(:id, :title, :source, :source_url, :store, :store_url, :main_image, :sub_image_first, :sub_image_second, dish_attributes: [ :id, :introduction, :description ], post_area_tags_attributes: [ :id, area_tag_attributes: [ :id, :name ] ], post_genre_tags_attributes: [ :id, genre_tag_attributes: [ :id, :name ] ], post_taste_tags_attributes: [ :id, taste_tag_attributes: [ :id, :name ] ], post_outher_tags_attributes: [ :id, outher_tag_attributes: [ :id, :name ] ])
   end
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -127,16 +127,21 @@
   </div>
 
   <div class="mt-3">
+    <%= f.label :source_url, t("posts.post_info.source_url") %>
+    <%= f.text_field :source_url, class: "form-control" %>
+  </div>
+
+  <div class="mt-3">
+    <%= f.label :store, t("posts.post_info.store") %>
+    <%= f.text_field :store, class: "form-control" %>
+  </div>
+
+  <div class="mt-3">
     <%= f.label :store_url, t("posts.post_info.store_url") %>
     <%= f.text_field :store_url, class: "form-control" %>
   </div>
 
   <%= f.fields_for :dish do |dish_f| %>
-    <div class="mt-3">
-      <%= dish_f.label :introduction, t("posts.post_info.introduction") %>
-      <%= dish_f.text_area :introduction, class: "form-control" %>
-    </div>
-
     <div class="mt-3">
       <%= dish_f.label :description, t("posts.post_info.description") %>
       <%= dish_f.text_area :description, class: "form-control" , rows: 9 %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -35,9 +35,17 @@
   </div>
 
   <div class="row">
-    <% if @post.store_url.present? %>
-      <%= t(".store_url", post_store_url: @post.store_url) %>
+    <%= @post.source_url %>
+  </div>
+
+  <div class="row">
+    <% if @post.store.present? %>
+      <%= t(".store", post_store: @post.store) %>
     <% end %>
+  </div>
+
+  <div class="row">
+    <%= @post.store_url %>
   </div>
 
   <%# -----------------------画像関連-------------------------- %>

--- a/config/locales/view_connection/ja.yml
+++ b/config/locales/view_connection/ja.yml
@@ -195,7 +195,9 @@ ja:
       selected_sub_image_second: 〜サブ画像2に以下の画像が選択されてます〜
       please_select_image_again: もう一度画像を選んでください。選択がない場合既存の画像があればそちらが適用されます。
       source: 出典
-      store_url: 店舗情報
+      source_url: 出典のURL
+      store: 店舗情報
+      store_url: 店舗情報のURL
       introduction: 一覧用紹介文
       description: 詳細用紹介文(必須)
       tag_setting_info: タグ設定情報 (複数登録する場合は単語の間に「 , 」を入れてください)
@@ -213,7 +215,7 @@ ja:
     show:
       posted_by: "投稿者:"
       source: "出典: %{post_source}"
-      store_url: "店舗情報: %{post_store_url}"
+      store: "店舗情報: %{post_store}"
       whose_comment: "%{user_name}さんのコメント"
       all_comment_display: すべてのコメントを表示する
       not_login_description: "ログインすると料理が提供されている近隣店舗を調べることができます"

--- a/db/migrate/20250513132647_add_url_to_posts.rb
+++ b/db/migrate/20250513132647_add_url_to_posts.rb
@@ -1,0 +1,6 @@
+class AddUrlToPosts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :posts, :source_url, :string
+    add_column :posts, :store, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_07_080458) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_13_132647) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -140,6 +140,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_07_080458) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "source_url"
+    t.string "store"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -54,7 +54,6 @@ RSpec.describe "Posts", type: :system do
           attach_file "サブ画像２", Rails.root.join("spec/fixtures/files/1.jpg")
           fill_in "出典", with: "出典A"
           fill_in "店舗情報", with: "店A"
-          fill_in "一覧用紹介文", with: "いちらんせつめい"
           fill_in "詳細用紹介文", with: "しょうさいせつめい"
           fill_in "post[post_area_tags_attributes][0][area_tag_attributes][name]", with: "エリアA,エリアB"
           fill_in "post[post_genre_tags_attributes][0][genre_tag_attributes][name]", with: "ジャンルA,ジャンルB"
@@ -76,7 +75,6 @@ RSpec.describe "Posts", type: :system do
           attach_file "サブ画像２", Rails.root.join("spec/fixtures/files/1.jpg")
           fill_in "出典", with: "出典A"
           fill_in "店舗情報", with: "店A"
-          fill_in "一覧用紹介文", with: "いちらんせつめい"
           fill_in "詳細用紹介文", with: "しょうさいせつめい"
           fill_in "post[post_area_tags_attributes][0][area_tag_attributes][name]", with: "エリアA,エリアB"
           fill_in "post[post_genre_tags_attributes][0][genre_tag_attributes][name]", with: "ジャンルA,ジャンルB"
@@ -98,7 +96,6 @@ RSpec.describe "Posts", type: :system do
           attach_file "サブ画像２", Rails.root.join("spec/fixtures/files/1.jpg")
           fill_in "出典", with: "出典A"
           fill_in "店舗情報", with: "店A"
-          fill_in "一覧用紹介文", with: "いちらんせつめい"
           fill_in "詳細用紹介文", with: "しょうさいせつめい"
           fill_in "post[post_area_tags_attributes][0][area_tag_attributes][name]", with: "エリアA,エリアB"
           fill_in "post[post_genre_tags_attributes][0][genre_tag_attributes][name]", with: "ジャンルA,ジャンルB"
@@ -120,7 +117,6 @@ RSpec.describe "Posts", type: :system do
           attach_file "サブ画像２", Rails.root.join("spec/fixtures/files/1.jpg")
           fill_in "出典", with: "出典A"
           fill_in "店舗情報", with: "店A"
-          fill_in "一覧用紹介文", with: "いちらんせつめい"
           fill_in "詳細用紹介文", with: ""
           fill_in "post[post_area_tags_attributes][0][area_tag_attributes][name]", with: "エリアA,エリアB"
           fill_in "post[post_genre_tags_attributes][0][genre_tag_attributes][name]", with: "ジャンルA,ジャンルB"
@@ -142,7 +138,6 @@ RSpec.describe "Posts", type: :system do
           attach_file "サブ画像２", Rails.root.join("spec/fixtures/files/1.jpg")
           fill_in "出典", with: "出典A"
           fill_in "店舗情報", with: "店A"
-          fill_in "一覧用紹介文", with: "いちらんせつめい"
           fill_in "詳細用紹介文", with: "しょうさいせつめい"
           fill_in "post[post_area_tags_attributes][0][area_tag_attributes][name]", with: ""
           fill_in "post[post_genre_tags_attributes][0][genre_tag_attributes][name]", with: "ジャンルA,ジャンルB"
@@ -165,7 +160,6 @@ RSpec.describe "Posts", type: :system do
           attach_file "サブ画像２", Rails.root.join("spec/fixtures/files/susi.jpg")
           fill_in "出典", with: "出典B"
           fill_in "店舗情報", with: "店B"
-          fill_in "一覧用紹介文", with: "いちらんせつめいB"
           fill_in "詳細用紹介文", with: "しょうさいせつめいB"
           fill_in "post[post_area_tags_attributes][0][area_tag_attributes][name]", with: "エリアA,エリアB"
           fill_in "post[post_genre_tags_attributes][0][genre_tag_attributes][name]", with: "ジャンルA,ジャンルB"


### PR DESCRIPTION
概要
---
・Post(記事)テーブルにカラム追加

内容
---
- [x] db/migrate/20250513132647_add_url_to_posts.rb
・Post(記事)テーブルにsource_url(出典のURL)カラムとstore(店舗情報)カラムを追加。
・ビューやコントローラにもカラム追加を反映する。

- [x] デプロイ成功画面を確認する。